### PR TITLE
update dependency on sneeze to support docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jsonic": "^0.2.2",
     "lodash": "^3.10.1",
     "nid": "^0.3.2",
-    "sneeze": "^0.3.3"
+    "sneeze": "^0.3.4"
   },
   "devDependencies": {
     "docco": "0.7.0",


### PR DESCRIPTION
there's a fix in the latest version of swim-js, which needs to be pulled into seneca-mesh via sneeze.